### PR TITLE
benchmark comparing

### DIFF
--- a/profiling/README.md
+++ b/profiling/README.md
@@ -7,19 +7,18 @@ The script logs to files and generates a summary CSV with the
 
 ## Compare two branches
 
-The summary CSV can be compared in textual form:
+Two summary CSVs can be compared by plotting them as graphs:
 
 ```
 $ cd profiling/
 $ ./benchmark-cargo-test.sh ; git checkout master && ./benchmark-cargo-test.sh
-$ git diff --no-index --word-diff summary.mybranch.2019Jun19_15h13m12s.txt summary.master.2019Jun19_15h34m26s.txt
+$ ./plot.py summary.mybranch.2019Jun19_15h13m12s.txt summary.master.2019Jun19_15h34m26s.txt mybranch-vs-master-
+$ eog mybranch-vs-master-*png
 ```
 
-Another option is to merge the two files to visualize it with a plotter:
+Another option is to quickly compare in textual form:
 ```
-$ ( cat summary.mybranch.2019Jun19_15h13m12s.txt && tail -n +2 summary.master.2019Jun19_15h34m26s.txt ) > summary.csv
-$ python -c "print('\n'.join([a.replace(',', '', 2) for a in open('summary.csv').read().split('\n')]))" | sort -r > summary_merged_key.csv
-$ libreoffice summary_merged_key.csv # check "Comma" as separator while opening, then "Insert → Chart → Finish", right click on Y-Axis and "Scale → Logarithmic"
+$ git diff --no-index --word-diff summary.mybranch.2019Jun19_15h13m12s.txt summary.master.2019Jun19_15h34m26s.txt
 ```
 
 # Profiling

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -1,0 +1,61 @@
+# Benchmark
+
+The benchmark script applies HTTP, gRPC, and TCP workloads with
+the benchmark utilities wrk2, strest-grpc, and iperf.
+The script logs to files and generates a summary CSV with the
+99th percentile latencies (or GBit/s for TCP).
+
+## Compare two branches
+
+The summary CSV can be compared in textual form:
+
+```
+$ cd profiling/
+$ ./benchmark-cargo-test.sh ; git checkout master && ./benchmark-cargo-test.sh
+$ git diff --no-index --word-diff summary.mybranch.2019Jun19_15h13m12s.txt summary.master.2019Jun19_15h34m26s.txt
+```
+
+Another option is to merge the two files to visualize it with a plotter:
+```
+$ ( cat summary.mybranch.2019Jun19_15h13m12s.txt && tail -n +2 summary.master.2019Jun19_15h34m26s.txt ) > summary.csv
+$ python -c "print('\n'.join([a.replace(',', '', 2) for a in open('summary.csv').read().split('\n')]))" | sort -r > summary_merged_key.csv
+$ libreoffice summary_merged_key.csv # check "Comma" as separator while opening, then "Insert → Chart → Finish", right click on Y-Axis and "Scale → Logarithmic"
+```
+
+# Profiling
+
+Profiling needs to have a build with debug symbols but optimizations.
+The build script will generate such a binary but needs to be run
+manually before the profiling if the source code changed.
+
+The profiling happens while the benchmark workload is applied.
+
+## Trace function calls with perf
+
+Trace function call stacks (2000 per second) and generate flamegraphs:
+
+```
+$ ./profiling-build.sh # if needed
+$ ./profiling-run.sh
+$ firefox/chrome *svg  # view flamegraph
+```
+
+
+## Trace memory allocations
+
+Trace heap memory allocations and generate flamegraphs:
+
+```
+$ ./profiling-build.sh # if needed
+$ ./profiling-heap.sh
+$ heaptrack -a ….heaptrack.dat  # view report
+```
+
+## Log memory usage
+
+Report program memory and actively used part of it:
+
+```
+$ ./profiling-build.sh # if needed
+$ ./profiling-wss.sh
+```

--- a/profiling/benchmark-cargo-test.sh
+++ b/profiling/benchmark-cargo-test.sh
@@ -33,6 +33,11 @@ single_benchmark_run () {
   fi
   $SERVER &
   SPID=$!
+  # wait for service to start
+  until ss -tan | grep "LISTEN.*:$SERVER_PORT"
+  do
+    sleep 1
+  done
   # wait for proxy to start
   until ss -tan | grep "LISTEN.*:$PROXY_PORT"
   do

--- a/profiling/benchmark-cargo-test.sh
+++ b/profiling/benchmark-cargo-test.sh
@@ -44,10 +44,10 @@ single_benchmark_run () {
       strest-grpc client --interval 10s --totalTargetRps $r --streams 4 --connections 4 --iterations 2 --address "127.0.0.1:$PROXY_PORT" --clientTimeout 1s | tee "$NAME-$r-rps.$ID.txt"
     done
   fi
-  # signal that proxy can terminate now
-  echo F | nc localhost 7777 || true
   # kill server
   kill $SPID
+  # signal that proxy can terminate now
+  echo F | nc localhost 7777 || true
   ) &
   PROFILING_SUPPORT_SERVER="127.0.0.1:$SERVER_PORT" cargo test --release profiling_setup -- --exact profiling_setup --nocapture
 }

--- a/profiling/benchmark-cargo-test.sh
+++ b/profiling/benchmark-cargo-test.sh
@@ -8,6 +8,11 @@ SERVER_PORT=8080
 PROFDIR=$(dirname "$0")
 ID=$(date +"%Y%h%d_%Hh%Mm%Ss")
 
+BRANCH_NAME=$(git symbolic-ref -q HEAD)
+BRANCH_NAME=${BRANCH_NAME##refs/heads/}
+BRANCH_NAME=${BRANCH_NAME:-HEAD}
+BRANCH_NAME=$(echo $BRANCH_NAME | sed -e 's/\//-/g')
+
 cd "$PROFDIR"
 which actix-web-server || cargo install --path actix-web-server
 which actix-web-server || ( echo "Please add ~/.cargo/bin to your PATH" ; exit 1 )
@@ -15,6 +20,8 @@ which wrk || ( echo "wrk not found: Compile the wrk binary from https://github.c
 which strest-grpc || ( echo "strest-grpc not found: Compile binary from https://github.com/BuoyantIO/strest-grpc and move it to your PATH" ; exit 1 )
 
 trap '{ killall iperf actix-web-server strest-grpc >& /dev/null; }' EXIT
+
+echo "Test, target req/s, branch, p999 latency (ms), GBit/s" > "summary.$BRANCH_NAME.$ID.txt"
 
 single_benchmark_run () {
   (
@@ -33,15 +40,23 @@ single_benchmark_run () {
   done
   if [ "$MODE" = "TCP" ]; then
     iperf -t 6 -p "$PROXY_PORT" -c localhost | tee "$NAME.$ID.txt"
+    T=$(grep "/sec" "$NAME.$ID.txt" | cut -d' ' -f12)
+    echo "TCP $DIRECTION, 0, $BRANCH_NAME, 0, $T" >> "summary.$BRANCH_NAME.$ID.txt"
   elif [ "$MODE" = "HTTP" ]; then
     for r in 4000 8000 16000; do
-      for i in 1 2; do
+      S=0
+      for i in 1 2 3 4 5; do
         wrk -d 10s -c 4 -t 4 -L -s wrk-report.lua -R $r -H 'Host: transparency.test.svc.cluster.local' "http://127.0.0.1:$PROXY_PORT/" | tee "$NAME$i-$r-rps.$ID.txt"
+        T=$(tac "$NAME$i-$r-rps.$ID.txt" | grep -m 1 0.999 | cut -d':' -f2 | awk '{print $1}')
+        S=$(python -c "print(max($S, $T))")
       done
+      echo "HTTP $DIRECTION, $r, $BRANCH_NAME, $S, 0" >> "summary.$BRANCH_NAME.$ID.txt"
     done
   else
     for r in 4000 8000; do
-      strest-grpc client --interval 10s --totalTargetRps $r --streams 4 --connections 4 --iterations 2 --address "127.0.0.1:$PROXY_PORT" --clientTimeout 1s | tee "$NAME-$r-rps.$ID.txt"
+      strest-grpc client --interval 10s --totalTargetRps $r --streams 4 --connections 4 --iterations 5 --address "127.0.0.1:$PROXY_PORT" --clientTimeout 1s | tee "$NAME-$r-rps.$ID.txt"
+      T=$(grep -m 1 p999 "$NAME-$r-rps.$ID.txt" | cut -d':' -f2)
+      echo "gRPC $DIRECTION, $r, $BRANCH_NAME, $T, 0" >> "summary.$BRANCH_NAME.$ID.txt"
     done
   fi
   # kill server
@@ -52,11 +67,13 @@ single_benchmark_run () {
   PROFILING_SUPPORT_SERVER="127.0.0.1:$SERVER_PORT" cargo test --release profiling_setup -- --exact profiling_setup --nocapture
 }
 
-MODE=TCP NAME=tcpoutbound_bench PROXY_PORT=$PROXY_PORT_OUTBOUND single_benchmark_run
-MODE=TCP NAME=tcpinbound_bench PROXY_PORT=$PROXY_PORT_INBOUND single_benchmark_run
-MODE=HTTP NAME=outbound_bench PROXY_PORT=$PROXY_PORT_OUTBOUND single_benchmark_run
-MODE=HTTP NAME=inbound_bench PROXY_PORT=$PROXY_PORT_INBOUND single_benchmark_run
-# outbount gRPC is not working # MODE=gRPC NAME=grpcoutbound_bench PROXY_PORT=$PROXY_PORT_OUTBOUND single_benchmark_run
-MODE=gRPC NAME=grpcinbound_bench PROXY_PORT=$PROXY_PORT_INBOUND single_benchmark_run
+MODE=TCP DIRECTION=outbound NAME=tcpoutbound_bench PROXY_PORT=$PROXY_PORT_OUTBOUND single_benchmark_run
+MODE=TCP DIRECTION=inbound NAME=tcpinbound_bench PROXY_PORT=$PROXY_PORT_INBOUND single_benchmark_run
+MODE=HTTP DIRECTION=outbound NAME=http1outbound_bench PROXY_PORT=$PROXY_PORT_OUTBOUND single_benchmark_run
+MODE=HTTP DIRECTION=inbound NAME=http1inbound_bench PROXY_PORT=$PROXY_PORT_INBOUND single_benchmark_run
+# outbount gRPC is not working
+MODE=gRPC DIRECTION=inbound NAME=grpcinbound_bench PROXY_PORT=$PROXY_PORT_INBOUND single_benchmark_run
 echo "Benchmark results (display with 'head -vn-0 *$ID.txt | less'):"
 ls *$ID*.txt
+echo SUMMARY:
+cat "summary.$BRANCH_NAME.$ID.txt"

--- a/profiling/benchmark-cargo-test.sh
+++ b/profiling/benchmark-cargo-test.sh
@@ -12,6 +12,7 @@ BRANCH_NAME=$(git symbolic-ref -q HEAD)
 BRANCH_NAME=${BRANCH_NAME##refs/heads/}
 BRANCH_NAME=${BRANCH_NAME:-HEAD}
 BRANCH_NAME=$(echo $BRANCH_NAME | sed -e 's/\//-/g')
+BRANCH_NAME=$BRANCH_NAME$ID
 
 cd "$PROFDIR"
 which actix-web-server || cargo install --path actix-web-server
@@ -21,7 +22,7 @@ which strest-grpc || ( echo "strest-grpc not found: Compile binary from https://
 
 trap '{ killall iperf actix-web-server strest-grpc >& /dev/null; }' EXIT
 
-echo "Test, target req/s, branch, p999 latency (ms), GBit/s" > "summary.$BRANCH_NAME.$ID.txt"
+echo "Test, target req/s, branch, p999 latency (ms), GBit/s" > "summary.$BRANCH_NAME.txt"
 
 single_benchmark_run () {
   (
@@ -46,7 +47,7 @@ single_benchmark_run () {
   if [ "$MODE" = "TCP" ]; then
     iperf -t 6 -p "$PROXY_PORT" -c localhost | tee "$NAME.$ID.txt"
     T=$(grep "/sec" "$NAME.$ID.txt" | cut -d' ' -f12)
-    echo "TCP $DIRECTION, 0, $BRANCH_NAME, 0, $T" >> "summary.$BRANCH_NAME.$ID.txt"
+    echo "TCP $DIRECTION, 0, $BRANCH_NAME, 0, $T" >> "summary.$BRANCH_NAME.txt"
   elif [ "$MODE" = "HTTP" ]; then
     for r in 4000 8000 16000; do
       S=0
@@ -55,13 +56,13 @@ single_benchmark_run () {
         T=$(tac "$NAME$i-$r-rps.$ID.txt" | grep -m 1 0.999 | cut -d':' -f2 | awk '{print $1}')
         S=$(python -c "print(max($S, $T))")
       done
-      echo "HTTP $DIRECTION, $r, $BRANCH_NAME, $S, 0" >> "summary.$BRANCH_NAME.$ID.txt"
+      echo "HTTP $DIRECTION, $r, $BRANCH_NAME, $S, 0" >> "summary.$BRANCH_NAME.txt"
     done
   else
     for r in 4000 8000; do
       strest-grpc client --interval 10s --totalTargetRps $r --streams 4 --connections 4 --iterations 5 --address "127.0.0.1:$PROXY_PORT" --clientTimeout 1s | tee "$NAME-$r-rps.$ID.txt"
       T=$(grep -m 1 p999 "$NAME-$r-rps.$ID.txt" | cut -d':' -f2)
-      echo "gRPC $DIRECTION, $r, $BRANCH_NAME, $T, 0" >> "summary.$BRANCH_NAME.$ID.txt"
+      echo "gRPC $DIRECTION, $r, $BRANCH_NAME, $T, 0" >> "summary.$BRANCH_NAME.txt"
     done
   fi
   # kill server
@@ -81,4 +82,4 @@ MODE=gRPC DIRECTION=inbound NAME=grpcinbound_bench PROXY_PORT=$PROXY_PORT_INBOUN
 echo "Benchmark results (display with 'head -vn-0 *$ID.txt | less'):"
 ls *$ID*.txt
 echo SUMMARY:
-cat "summary.$BRANCH_NAME.$ID.txt"
+cat "summary.$BRANCH_NAME.txt"

--- a/profiling/plot.py
+++ b/profiling/plot.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import pandas as pd
+import matplotlib
+import matplotlib.pyplot as plt
+import argparse
+
+parser = argparse.ArgumentParser(description='Plot two CSV results for comparison.')
+parser.add_argument('input1', type=str, help='First CSV result file')
+parser.add_argument('input2', type=str, help='Second CSV result file')
+parser.add_argument('outputprefix', type=str, help='Prefix to use for the PNG graph files')
+args = parser.parse_args()
+
+g = pd.concat([pd.read_csv(args.input1, index_col=["Test", " target req/s"]), pd.read_csv(args.input2, index_col=["Test", " target req/s"])])
+g.groupby(level=["Test", " target req/s"])
+
+only_gbits = g[[" branch", " GBit/s"]][ g[" GBit/s"] > 0 ]
+rearrange_gbits = only_gbits.pivot_table(index = ['Test', ' target req/s'], columns = " branch", values = " GBit/s")
+rearrange_gbits.plot(kind='bar', title="Throughput (GBit/s)", figsize=(10, 8))
+plt.xticks(rotation = 0)
+outfile_gbits = args.outputprefix + "gbits.png"
+print("Save graph to", outfile_gbits)
+plt.savefig(outfile_gbits, bbox_inches='tight')
+
+only_latency = g[[" branch", " p999 latency (ms)"]][ g[" p999 latency (ms)"] > 0 ]
+rearrange_latency = only_latency.pivot_table(index = ['Test', ' target req/s'], columns = " branch", values = " p999 latency (ms)")
+rearrange_latency.plot(kind='bar', logy=True, title="p999 Latency (ms)", figsize=(13, 3), fontsize=7)
+plt.xticks(rotation = 0)
+outfile_latency = args.outputprefix + "latency.png"
+print("Save graph to", outfile_latency)
+plt.savefig(outfile_latency, bbox_inches='tight')
+
+print("Plotted sucessfully")


### PR DESCRIPTION
- Generate csv file for benchmark result
    The csv file contains the results for a single branch.
    Branches can be compared by comparing their files or
    by generating a merged file in order to plot it.
- Prevent race when (re)starting the benchmark server
- Gather more data by running multiple times
    Rerunning a test gives sometimes higher tail latencies
    than running for a longer time.