### PR TITLE
profiling: make sure that there's a single profiling binary

### DIFF
--- a/profiling/profiling-build.sh
+++ b/profiling/profiling-build.sh
@@ -6,4 +6,5 @@ PROFDIR=$(dirname "$0")
 cd "$PROFDIR"
 rm ../target/release/profiling-* || true
 RUSTFLAGS="-C debuginfo=2 -C lto=off" cargo test --release --no-run profiling_setup  # try lto=thin or =fat if they don't make perf miss calls
+[[ $(/bin/ls -1 ../target/release/profiling-*[^.d] | wc -l) -gt 1 ]] && (echo "There are multiple profiling binaries under ../target/release. Please clean up."; exit 1)
 mv ../target/release/profiling-*[^.d] ../target/release/profiling-opt-and-dbg-symbols # ignore .d folder

--- a/profiling/profiling-heap.sh
+++ b/profiling/profiling-heap.sh
@@ -7,13 +7,14 @@ PROXY_PORT_INBOUND=4143
 SERVER_PORT=8080
 PROFDIR=$(dirname "$0")
 ID=$(date +"%Y%h%d_%Hh%Mm%Ss")
+LINKERD_TEST_BIN="../target/release/profiling-opt-and-dbg-symbols"
 
 cd "$PROFDIR"
 which actix-web-server || cargo install --path actix-web-server
 which actix-web-server || ( echo "Please add ~/.cargo/bin to your PATH" ; exit 1 )
 which wrk || ( echo "wrk not found: Compile the wrk binary from https://github.com/kinvolk/wrk2/ and move it to your PATH" ; exit 1 )
 ls libmemory_profiler.so memory-profiler-cli || ( curl -L -O https://github.com/nokia/memory-profiler/releases/download/0.3.0/memory-profiler-x86_64-unknown-linux-gnu.tgz ; tar xf memory-profiler-x86_64-unknown-linux-gnu.tgz ; rm memory-profiler-x86_64-unknown-linux-gnu.tgz )
-ls ../target/release/profiling-opt-and-dbg-symbols || ( echo "../target/release/profiling-opt-and-dbg-symbols not found: Please run ./profiling-build.sh" ; exit 1 )
+ls $LINKERD_TEST_BIN || ( echo "$LINKERD_TEST_BIN not found: Please run ./profiling-build.sh" ; exit 1 )
 
 trap '{ killall iperf actix-web-server >& /dev/null; }' EXIT
 
@@ -41,7 +42,7 @@ single_profiling_run () {
   kill $SPID
   ) &
   rm memory-profiling_*.dat || true
-  PROFILING_SUPPORT_SERVER="127.0.0.1:$SERVER_PORT" LD_PRELOAD=./libmemory_profiler.so ../target/release/profiling-opt-and-dbg-symbols --exact profiling_setup --nocapture
+  PROFILING_SUPPORT_SERVER="127.0.0.1:$SERVER_PORT" LD_PRELOAD=./libmemory_profiler.so $LINKERD_TEST_BIN --exact profiling_setup --nocapture
   mv memory-profiling_*.dat "$NAME.$ID.heap.dat"
   ./memory-profiler-cli export-heaptrack "$NAME.$ID.heap.dat" --output "$NAME.$ID.heaptrack.dat"
 }

--- a/profiling/profiling-wss.sh
+++ b/profiling/profiling-wss.sh
@@ -7,12 +7,13 @@ PROXY_PORT_INBOUND=4143
 SERVER_PORT=8080
 PROFDIR=$(dirname "$0")
 ID=$(date +"%Y%h%d_%Hh%Mm%Ss")
+LINKERD_TEST_BIN="../target/release/profiling-opt-and-dbg-symbols"
 
 cd "$PROFDIR"
 which actix-web-server || cargo install --path actix-web-server
 which actix-web-server || ( echo "Please add ~/.cargo/bin to your PATH" ; exit 1 )
 which wrk || ( echo "wrk not found: Compile the wrk binary from https://github.com/kinvolk/wrk2/ and move it to your PATH" ; exit 1 )
-ls ../target/release/profiling-opt-and-dbg-symbols || ( echo "../target/release/profiling-opt-and-dbg-symbols not found: Please run ./profiling-build.sh" ; exit 1 )
+ls $LINKERD_TEST_BIN || ( echo "$LINKERD_TEST_BIN not found: Please run ./profiling-build.sh" ; exit 1 )
 ./wss.pl -h 2> /dev/null && RET=$? || RET=$?
 if [ $RET -eq 2 ]; then
   echo "wss.pl can not start: Install the perl-Time-HiRes package of your distribution"
@@ -34,7 +35,6 @@ single_profiling_run () {
   do
     sleep 1
   done
-  LINKERD_TEST_BIN=$(ls ../target/release/profiling-*[^.d])
   ( ./wss.pl $(pgrep -f -x "$LINKERD_TEST_BIN --exact profiling_setup --nocapture") 6 | tee "wss_$NAME.$ID.txt" ) &
   if [ "$MODE" = "TCP" ]; then
     iperf -t 6 -p "$PROXY_PORT" -c localhost | tee "$NAME.$ID.txt"
@@ -49,7 +49,7 @@ single_profiling_run () {
   # kill server
   kill $SPID
   ) &
-  PROFILING_SUPPORT_SERVER="127.0.0.1:$SERVER_PORT" ../target/release/profiling-opt-and-dbg-symbols --exact profiling_setup --nocapture
+  PROFILING_SUPPORT_SERVER="127.0.0.1:$SERVER_PORT" $LINKERD_TEST_BIN --exact profiling_setup --nocapture
 }
 
 MODE=TCP NAME=tcpoutbound PROXY_PORT=$PROXY_PORT_OUTBOUND single_profiling_run


### PR DESCRIPTION
After building linkerd2-proxy, we need to make sure that there's only one single `profiling` binary. If there are multiple binaries, the next actions will somehow fail in a subtle way.

Also use `LINKERD2_TEST_BIN` variable instead of hard-coding the `profiling` binary name.