### PR TITLE
profiling: Fix gRPC outbound test through hostname instead of an IP

### DIFF
--- a/profiling/benchmark-cargo-test.sh
+++ b/profiling/benchmark-cargo-test.sh
@@ -52,7 +52,7 @@ single_benchmark_run () {
     for r in 4000 8000 16000; do
       S=0
       for i in 1 2 3 4 5; do
-        wrk -d 10s -c 4 -t 4 -L -s wrk-report.lua -R $r -H 'Host: transparency.test.svc.cluster.local' "http://127.0.0.1:$PROXY_PORT/" | tee "$NAME$i-$r-rps.$ID.txt"
+        wrk -d 10s -c 4 -t 4 -L -s wrk-report.lua -R $r -H 'Host: transparency.test.svc.cluster.local' "http://localhost:$PROXY_PORT/" | tee "$NAME$i-$r-rps.$ID.txt"
         T=$(tac "$NAME$i-$r-rps.$ID.txt" | grep -m 1 0.999 | cut -d':' -f2 | awk '{print $1}')
         S=$(python -c "print(max($S, $T))")
       done
@@ -60,7 +60,7 @@ single_benchmark_run () {
     done
   else
     for r in 4000 8000; do
-      strest-grpc client --interval 10s --totalTargetRps $r --streams 4 --connections 4 --iterations 5 --address "127.0.0.1:$PROXY_PORT" --clientTimeout 1s | tee "$NAME-$r-rps.$ID.txt"
+      strest-grpc client --interval 10s --totalTargetRps $r --streams 4 --connections 4 --iterations 5 --address "localhost:$PROXY_PORT" --clientTimeout 1s | tee "$NAME-$r-rps.$ID.txt"
       T=$(grep -m 1 p999 "$NAME-$r-rps.$ID.txt" | cut -d':' -f2)
       echo "gRPC $DIRECTION, $r, $BRANCH_NAME, $T, 0" >> "summary.$BRANCH_NAME.txt"
     done
@@ -77,7 +77,7 @@ MODE=TCP DIRECTION=outbound NAME=tcpoutbound_bench PROXY_PORT=$PROXY_PORT_OUTBOU
 MODE=TCP DIRECTION=inbound NAME=tcpinbound_bench PROXY_PORT=$PROXY_PORT_INBOUND single_benchmark_run
 MODE=HTTP DIRECTION=outbound NAME=http1outbound_bench PROXY_PORT=$PROXY_PORT_OUTBOUND single_benchmark_run
 MODE=HTTP DIRECTION=inbound NAME=http1inbound_bench PROXY_PORT=$PROXY_PORT_INBOUND single_benchmark_run
-# outbount gRPC is not working
+MODE=gRPC DIRECTION=outbound NAME=grpcoutbound_bench PROXY_PORT=$PROXY_PORT_OUTBOUND single_benchmark_run
 MODE=gRPC DIRECTION=inbound NAME=grpcinbound_bench PROXY_PORT=$PROXY_PORT_INBOUND single_benchmark_run
 echo "Benchmark results (display with 'head -vn-0 *$ID.txt | less'):"
 ls *$ID*.txt

--- a/profiling/plot.py
+++ b/profiling/plot.py
@@ -23,7 +23,7 @@ plt.savefig(outfile_gbits, bbox_inches='tight')
 
 only_latency = g[[" branch", " p999 latency (ms)"]][ g[" p999 latency (ms)"] > 0 ]
 rearrange_latency = only_latency.pivot_table(index = ['Test', ' target req/s'], columns = " branch", values = " p999 latency (ms)")
-rearrange_latency.plot(kind='bar', logy=True, title="p999 Latency (ms)", figsize=(13, 3), fontsize=7)
+rearrange_latency.plot(kind='bar', logy=True, title="p999 Latency (ms)", figsize=(15, 3), fontsize=7)
 plt.xticks(rotation = 0)
 outfile_latency = args.outputprefix + "latency.png"
 print("Save graph to", outfile_latency)

--- a/profiling/profiling-heap.sh
+++ b/profiling/profiling-heap.sh
@@ -34,7 +34,7 @@ single_profiling_run () {
   if [ "$MODE" = "TCP" ]; then
     iperf -t 6 -p "$PROXY_PORT" -c localhost | tee "$NAME.$ID.txt"
   else
-    wrk -L -s wrk-report.lua -R 4500 -H 'Host: transparency.test.svc.cluster.local' "http://127.0.0.1:$PROXY_PORT/" | tee "$NAME.$ID.txt"
+    wrk -L -s wrk-report.lua -R 4500 -H 'Host: transparency.test.svc.cluster.local' "http://localhost:$PROXY_PORT/" | tee "$NAME.$ID.txt"
   fi
   # signal that proxy can terminate now
   echo F | nc localhost 7777 || true

--- a/profiling/profiling-run.sh
+++ b/profiling/profiling-run.sh
@@ -40,7 +40,7 @@ single_profiling_run () {
   if [ "$MODE" = "TCP" ]; then
     iperf -t 6 -p "$PROXY_PORT" -c localhost | tee "$NAME.$ID.txt"
   else
-    wrk -L -s wrk-report.lua -R 4500 -H 'Host: transparency.test.svc.cluster.local' "http://127.0.0.1:$PROXY_PORT/" | tee "$NAME.$ID.txt"
+    wrk -L -s wrk-report.lua -R 4500 -H 'Host: transparency.test.svc.cluster.local' "http://localhost:$PROXY_PORT/" | tee "$NAME.$ID.txt"
   fi
   # signal that proxy can terminate now
   echo F | nc localhost 7777 || true

--- a/profiling/profiling-wss.sh
+++ b/profiling/profiling-wss.sh
@@ -39,7 +39,7 @@ single_profiling_run () {
   if [ "$MODE" = "TCP" ]; then
     iperf -t 6 -p "$PROXY_PORT" -c localhost | tee "$NAME.$ID.txt"
   else
-    wrk -L -s wrk-report.lua -R 4500 -H 'Host: transparency.test.svc.cluster.local' "http://127.0.0.1:$PROXY_PORT/" | tee "$NAME.$ID.txt"
+    wrk -L -s wrk-report.lua -R 4500 -H 'Host: transparency.test.svc.cluster.local' "http://localhost:$PROXY_PORT/" | tee "$NAME.$ID.txt"
   fi
   while pgrep wss.pl; do
     sleep 1


### PR DESCRIPTION
Even with curl --http2 or --http2-prior-knowledge connections on
the outbound port were not forwarded (-prior-kowledge even looped)
because the hostname was an IP and not localhost.
This is maybe something that should work in Linkerd but this test proxy setup is a bit different from real usage, so I'll test it with iptables first before reporting.