### PR TITLE
profiling: Customize benchmark parameters through env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ profiling/*dat
 profiling/memory-profiler-*
 profiling/libmemory_profiler.so
 profiling/perf.data
+profiling/wrk-report-tmp.lua

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -21,6 +21,30 @@ Another option is to quickly compare in textual form:
 $ git diff --no-index --word-diff summary.mybranch.2019Jun19_15h13m12s.txt summary.master.2019Jun19_15h34m26s.txt
 ```
 
+## Customize Parameters
+
+The benchmark script takes the following environment variables to determine the test parameters.
+When not provided they default to the values as listed here.
+
+`ITERATIONS="5"`: The number of times a single HTTP/gRPC benchmark run is repeated to observe the maximal tail latency.
+
+`DURATION="10s"`: Execution time for a single HTTP/gRPC benchmark run.
+
+`CONNECTIONS="4"`: Number of concurrent TCP connections for HTTP/gRPC.
+
+`GRPC_STREAMS="4"`: Number of HTTP/2 streams in a connection.
+
+`HTTP_RPS="4000 8000 16000"`: Different target HTTP req/s numbers as space-separated list. It may not be achieved if too high.
+Please see the actual req/s in the log output.
+
+`GRPC_RPS="4000 8000"`: As above but for gRPC.
+
+Dummy values to illustrate usage for a quick test run:
+
+```
+$ ITERATIONS=2 DURATION=2s CONNECTIONS=2 GRPC_STREAMS=2 HTTP_RPS="100 1000" GRPC_RPS="100 1000" ./benchmark-cargo-test.sh
+```
+
 # Profiling
 
 Profiling needs to have a build with debug symbols but optimizations.

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -39,10 +39,12 @@ Please see the actual req/s in the log output.
 
 `GRPC_RPS="4000 8000"`: As above but for gRPC.
 
+`REQ_BODY_LEN="100"`: Length of the request body payload in byte.
+
 Dummy values to illustrate usage for a quick test run:
 
 ```
-$ ITERATIONS=2 DURATION=2s CONNECTIONS=2 GRPC_STREAMS=2 HTTP_RPS="100 1000" GRPC_RPS="100 1000" ./benchmark-cargo-test.sh
+$ ITERATIONS=2 DURATION=2s CONNECTIONS=2 GRPC_STREAMS=2 HTTP_RPS="100 1000" GRPC_RPS="100 1000" REQ_BODY_LEN="8000" ./benchmark-cargo-test.sh
 ```
 
 # Profiling

--- a/profiling/benchmark-cargo-test.sh
+++ b/profiling/benchmark-cargo-test.sh
@@ -2,6 +2,12 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+ITERATIONS="${ITERATIONS-5}"
+DURATION="${DURATION-10s}"
+CONNECTIONS="${CONNECTIONS-4}"
+GRPC_STREAMS="${GRPC_STREAMS-4}"
+HTTP_RPS="${HTTP_RPS-4000 8000 16000}"
+GRPC_RPS="${GRPC_RPS-4000 8000}"
 PROXY_PORT_OUTBOUND=4140
 PROXY_PORT_INBOUND=4143
 SERVER_PORT=8080
@@ -12,7 +18,7 @@ BRANCH_NAME=$(git symbolic-ref -q HEAD)
 BRANCH_NAME=${BRANCH_NAME##refs/heads/}
 BRANCH_NAME=${BRANCH_NAME:-HEAD}
 BRANCH_NAME=$(echo $BRANCH_NAME | sed -e 's/\//-/g')
-BRANCH_NAME=$BRANCH_NAME$ID
+RUN_NAME="$BRANCH_NAME $ID Iter: $ITERATIONS Dur: $DURATION Conns: $CONNECTIONS Streams: $GRPC_STREAMS"
 
 cd "$PROFDIR"
 which actix-web-server || cargo install --path actix-web-server
@@ -22,7 +28,7 @@ which strest-grpc || ( echo "strest-grpc not found: Compile binary from https://
 
 trap '{ killall iperf actix-web-server strest-grpc >& /dev/null; }' EXIT
 
-echo "Test, target req/s, branch, p999 latency (ms), GBit/s" > "summary.$BRANCH_NAME.txt"
+echo "Test, target req/s, branch, p999 latency (ms), GBit/s" > "summary.$RUN_NAME.txt"
 
 single_benchmark_run () {
   (
@@ -47,22 +53,26 @@ single_benchmark_run () {
   if [ "$MODE" = "TCP" ]; then
     iperf -t 6 -p "$PROXY_PORT" -c localhost | tee "$NAME.$ID.txt"
     T=$(grep "/sec" "$NAME.$ID.txt" | cut -d' ' -f12)
-    echo "TCP $DIRECTION, 0, $BRANCH_NAME, 0, $T" >> "summary.$BRANCH_NAME.txt"
+    echo "TCP $DIRECTION, 0, $RUN_NAME, 0, $T" >> "summary.$RUN_NAME.txt"
   elif [ "$MODE" = "HTTP" ]; then
-    for r in 4000 8000 16000; do
+    for r in $HTTP_RPS; do
       S=0
-      for i in 1 2 3 4 5; do
-        wrk -d 10s -c 4 -t 4 -L -s wrk-report.lua -R $r -H 'Host: transparency.test.svc.cluster.local' "http://localhost:$PROXY_PORT/" | tee "$NAME$i-$r-rps.$ID.txt"
-        T=$(tac "$NAME$i-$r-rps.$ID.txt" | grep -m 1 0.999 | cut -d':' -f2 | awk '{print $1}')
+      for i in $(seq $ITERATIONS); do
+        wrk -d "$DURATION" -c "$CONNECTIONS" -t "$CONNECTIONS" -L -s wrk-report.lua -R "$r" -H 'Host: transparency.test.svc.cluster.local' "http://localhost:$PROXY_PORT/" | tee "$NAME$i-$r-rps.$ID.txt"
+        T=$(tac "$NAME$i-$r-rps.$ID.txt" | grep -m 1 "^ .*0.99*" | cut -d':' -f2 | awk '{print $1}')
+        if [ -z "$T" ]; then
+          echo "No values for 0.9 percentiles found"
+          exit 1
+        fi
         S=$(python -c "print(max($S, $T))")
       done
-      echo "HTTP $DIRECTION, $r, $BRANCH_NAME, $S, 0" >> "summary.$BRANCH_NAME.txt"
+      echo "HTTP $DIRECTION, $r, $RUN_NAME, $S, 0" >> "summary.$RUN_NAME.txt"
     done
   else
-    for r in 4000 8000; do
-      strest-grpc client --interval 10s --totalTargetRps $r --streams 4 --connections 4 --iterations 5 --address "localhost:$PROXY_PORT" --clientTimeout 1s | tee "$NAME-$r-rps.$ID.txt"
+    for r in $GRPC_RPS; do
+      strest-grpc client --interval "$DURATION" --totalTargetRps "$r" --streams "$GRPC_STREAMS" --connections "$CONNECTIONS" --iterations "$ITERATIONS" --address "localhost:$PROXY_PORT" --clientTimeout 1s | tee "$NAME-$r-rps.$ID.txt"
       T=$(grep -m 1 p999 "$NAME-$r-rps.$ID.txt" | cut -d':' -f2)
-      echo "gRPC $DIRECTION, $r, $BRANCH_NAME, $T, 0" >> "summary.$BRANCH_NAME.txt"
+      echo "gRPC $DIRECTION, $r, $RUN_NAME, $T, 0" >> "summary.$RUN_NAME.txt"
     done
   fi
   # kill server
@@ -82,4 +92,4 @@ MODE=gRPC DIRECTION=inbound NAME=grpcinbound_bench PROXY_PORT=$PROXY_PORT_INBOUN
 echo "Benchmark results (display with 'head -vn-0 *$ID.txt | less'):"
 ls *$ID*.txt
 echo SUMMARY:
-cat "summary.$BRANCH_NAME.txt"
+cat "summary.$RUN_NAME.txt"


### PR DESCRIPTION
The benchmark script takes the following environment variables to determine the test parameters.
When not provided they default to the values as listed here.

`ITERATIONS="5"`: The number of times a single HTTP/gRPC benchmark run is repeated to observe the maximal tail latency.

`DURATION="10s"`: Execution time for a single HTTP/gRPC benchmark run.

`CONNECTIONS="4"`: Number of concurrent TCP connections for HTTP/gRPC.

`GRPC_STREAMS="4"`: Number of HTTP/2 streams in a connection.

`HTTP_RPS="4000 8000 16000"`: Different target HTTP req/s numbers as space-separated list. It may not be achieved if too high.
Please see the actual req/s in the log output.

`GRPC_RPS="4000 8000"`: As above but for gRPC.

`REQ_BODY_LEN="100"`: Length of the request body payload in byte.
